### PR TITLE
Add splash screen feature with GoRouter navigation

### DIFF
--- a/lib/app/my_app.dart
+++ b/lib/app/my_app.dart
@@ -1,29 +1,27 @@
-import 'package:ai_movie_app/core/services/service_locator.dart';
-import 'package:ai_movie_app/feature/movies/presentation/bloc/movies_bloc.dart';
+import 'package:ai_movie_app/core/routes/app_router.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
-
-import '../feature/movies/presentation/screens/movies_details_screen.dart';
 
 class SceneHub extends StatelessWidget {
   const SceneHub({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      debugShowCheckedModeBanner: false,
-      home: ScreenUtilInit(
-        designSize: const Size(375, 812),
-        minTextAdapt: true,
-        splitScreenMode: true,
-        builder: (context, child) {
-          return BlocProvider(
-            create: (context) => MoviesBloc(sl()),
-            child: const MoviesDetailsScreen(),
-          );
-        },
-      ),
+    return ScreenUtilInit(
+      designSize: const Size(375, 812),
+      minTextAdapt: true,
+      splitScreenMode: true,
+      builder: (context, child) {
+        return
+        // BlocProvider(
+        //   create: (context) => MoviesBloc(sl()),
+        //   child:
+        MaterialApp.router(
+          debugShowCheckedModeBanner: false,
+          routerConfig: goRouter,
+        );
+        // );
+      },
     );
   }
 }

--- a/lib/core/constants/cache_keys.dart
+++ b/lib/core/constants/cache_keys.dart
@@ -1,3 +1,3 @@
-class CacheKeys {
+abstract class CacheKeys {
   static const String userData = 'user_data';
 }

--- a/lib/core/routes/app_router.dart
+++ b/lib/core/routes/app_router.dart
@@ -1,7 +1,10 @@
+import 'package:ai_movie_app/core/services/service_locator.dart';
 import 'package:ai_movie_app/feature/auth/presentation/auth_cubit/cubit/auth_cubit.dart';
 import 'package:ai_movie_app/feature/auth/presentation/views/forgot_password_view.dart';
 import 'package:ai_movie_app/feature/auth/presentation/views/sign_in_view.dart';
 import 'package:ai_movie_app/feature/auth/presentation/views/sign_up_view.dart';
+import 'package:ai_movie_app/feature/movies/presentation/bloc/movies_bloc.dart';
+import 'package:ai_movie_app/feature/movies/presentation/screens/movies_details_screen.dart';
 import 'package:ai_movie_app/feature/on_bourding/presentation/views/on_boarding_view.dart';
 import 'package:ai_movie_app/feature/splash/presentation/views/splash_view.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -14,7 +17,7 @@ const String homeView = "/HomeView";
 const String forgotPassword = "/ForgotPasswordView";
 const String homeNavBar = "/HomeNavBar";
 
-final GoRouter starterrouter = GoRouter(
+final GoRouter goRouter = GoRouter(
   routes: [
     GoRoute(path: "/", builder: (context, state) => const SplashView()),
     GoRoute(
@@ -46,6 +49,17 @@ final GoRouter starterrouter = GoRouter(
         create: (context) => AuthCubit(),
         child: const ForgotPasswordView(),
       ),
+    ),
+
+    GoRoute(
+      path: '$homeView/:id',
+      builder: (context, state) {
+        final movieId = int.parse(state.pathParameters['id']!);
+        return BlocProvider(
+          create: (context) => MoviesBloc(sl()),
+          child: MoviesDetailsScreen(movieId: movieId),
+        );
+      },
     ),
   ],
 );

--- a/lib/core/services/service_locator.dart
+++ b/lib/core/services/service_locator.dart
@@ -3,6 +3,10 @@ import 'package:ai_movie_app/feature/cast/data/repository/cast_repo_impl.dart';
 import 'package:ai_movie_app/feature/cast/domain/repository/cast_repo.dart';
 import 'package:ai_movie_app/feature/cast/domain/usecases/get_movies_cast_usecase.dart';
 import 'package:ai_movie_app/feature/movies/domain/repository/movies_repo.dart';
+import 'package:ai_movie_app/feature/splash/data/repositories/supabase_auth_repository.dart';
+import 'package:ai_movie_app/feature/splash/domain/repositories/auth_repository.dart';
+import 'package:ai_movie_app/feature/splash/domain/use_case/decide_start_destination_usecase.dart';
+import 'package:ai_movie_app/feature/splash/presentation/manager/splash_cubit.dart';
 import 'package:dio/dio.dart';
 import 'package:get_it/get_it.dart';
 
@@ -33,6 +37,19 @@ Future<void> initSl() async {
   sl.registerSingleton(appPreferences);
   sl.registerLazySingleton<Dio>(() => Dio());
   sl.registerLazySingleton<ApiConsumer>(() => DioConsumer(client: sl()));
+
+  // splash
+  sl.registerFactory(() => SplashCubit(sl()));
+
+  sl.registerLazySingleton<DecideStartDestinationUseCase>(
+    () => DecideStartDestinationUseCase(
+      appPreferences: sl<AppPreferences>(),
+      authRepository: sl<AuthRepository>(),
+    ),
+  );
+
+  // auth
+  sl.registerLazySingleton<AuthRepository>(() => SupabaseAuthRepository());
 
   //* Tv Series
   sl.registerLazySingleton<TvSeriesRemoteDatasource>(

--- a/lib/feature/splash/data/repositories/supabase_auth_repository.dart
+++ b/lib/feature/splash/data/repositories/supabase_auth_repository.dart
@@ -1,0 +1,9 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+import '../../domain/repositories/auth_repository.dart';
+
+class SupabaseAuthRepository implements AuthRepository {
+  @override
+  dynamic getCurrentUser() {
+    return Supabase.instance.client.auth.currentUser;
+  }
+}

--- a/lib/feature/splash/domain/repositories/auth_repository.dart
+++ b/lib/feature/splash/domain/repositories/auth_repository.dart
@@ -1,0 +1,4 @@
+abstract class AuthRepository {
+  dynamic getCurrentUser();
+}
+//! The domain layer must not depend on any external library (as per the principles of Clean Architecture).

--- a/lib/feature/splash/domain/use_case/decide_start_destination_usecase.dart
+++ b/lib/feature/splash/domain/use_case/decide_start_destination_usecase.dart
@@ -1,0 +1,31 @@
+import 'package:ai_movie_app/core/routes/app_router.dart';
+import 'package:ai_movie_app/feature/splash/domain/repositories/auth_repository.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../../../../core/database/cache/app_shared_preferences.dart';
+
+class DecideStartDestinationUseCase {
+  final AppPreferences appPreferences;
+  final AuthRepository authRepository;
+
+  DecideStartDestinationUseCase({
+    required this.appPreferences,
+    required this.authRepository,
+  });
+
+  Future<String> call() async {
+    final isVisited = appPreferences.getData('isOnBoardingVisited') ?? false;
+    final user = authRepository.getCurrentUser();
+    await Future.delayed(const Duration(seconds: 2));
+
+    return _decideNextRoute(isVisited, user);
+  }
+
+  String _decideNextRoute(bool isVisited, User? user) {
+    if (isVisited) {
+      return user != null ? homeNavBar : signInPage;
+    } else {
+      return toOnbourding;
+    }
+  }
+}

--- a/lib/feature/splash/presentation/manager/splash_cubit.dart
+++ b/lib/feature/splash/presentation/manager/splash_cubit.dart
@@ -1,0 +1,16 @@
+import 'package:ai_movie_app/feature/splash/domain/use_case/decide_start_destination_usecase.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+part 'splash_state.dart';
+
+class SplashCubit extends Cubit<SplashState> {
+  final DecideStartDestinationUseCase useCase;
+
+  SplashCubit(this.useCase) : super(SplashInitial());
+
+  Future<void> decideRoute() async {
+    emit(SplashLoading());
+    final route = await useCase();
+    emit(SplashNavigation(route));
+  }
+}

--- a/lib/feature/splash/presentation/manager/splash_state.dart
+++ b/lib/feature/splash/presentation/manager/splash_state.dart
@@ -1,0 +1,13 @@
+part of 'splash_cubit.dart';
+
+abstract class SplashState {}
+
+class SplashInitial extends SplashState {}
+
+class SplashLoading extends SplashState {}
+
+class SplashNavigation extends SplashState {
+  final String route;
+
+  SplashNavigation(this.route);
+}

--- a/lib/feature/splash/presentation/views/splash_view.dart
+++ b/lib/feature/splash/presentation/views/splash_view.dart
@@ -1,12 +1,9 @@
-import 'package:ai_movie_app/core/database/cache/app_shared_preferences.dart';
 import 'package:ai_movie_app/core/functions/navigation.dart';
-import 'package:ai_movie_app/core/functions/print_statement.dart';
-import 'package:ai_movie_app/core/routes/app_router.dart';
 import 'package:ai_movie_app/core/services/service_locator.dart';
 import 'package:ai_movie_app/core/utils/app_strings.dart';
 import 'package:ai_movie_app/core/utils/app_text_styles.dart';
+import 'package:ai_movie_app/feature/splash/domain/use_case/decide_start_destination_usecase.dart';
 import 'package:flutter/material.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
 
 class SplashView extends StatefulWidget {
   const SplashView({super.key});
@@ -19,12 +16,13 @@ class _SplashViewState extends State<SplashView> {
   @override
   void initState() {
     super.initState();
-    checkFirstVisitOrNot(
-      context,
-      'isOnBoardingVisited',
-      signInPage,
-      toOnbourding,
-    );
+    _navigateAfterSplash();
+  }
+
+  Future<void> _navigateAfterSplash() async {
+    final nextRoute = await sl<DecideStartDestinationUseCase>()();
+    if (!mounted) return;
+    customReplacementNavigate(context, nextRoute);
   }
 
   @override
@@ -39,50 +37,3 @@ class _SplashViewState extends State<SplashView> {
     );
   }
 }
-
-void checkFirstVisitOrNot(
-  BuildContext context,
-  String key,
-  String ifFirstContinue,
-  String ifNoTToOnBoarding,
-) {
-  bool isVisited = sl<AppPreferences>().getData(key) ?? false;
-
-  Future.delayed(const Duration(seconds: 2), () async {
-    if (!context.mounted) return;
-
-    final user = Supabase.instance.client.auth.currentUser;
-    printHere('Supabase User: $user');
-
-    if (isVisited) {
-      if (user != null) {
-        checkEmailVerifiedOrNotSupabase(context, homeNavBar, signInPage);
-      } else {
-        customReplacementNavigate(context, signInPage);
-      }
-    } else {
-      customReplacementNavigate(context, ifNoTToOnBoarding);
-    }
-  });
-}
-
-void checkEmailVerifiedOrNotSupabase(
-  BuildContext context,
-  String home,
-  String signIn,
-) {
-  final user = Supabase.instance.client.auth.currentUser;
-
-  if (user != null) {
-    customReplacementNavigate(context, home);
-  } else {
-    customReplacementNavigate(context, signIn);
-  }
-}
-
-// void checkEmailVerifiedOrNot(
-//     BuildContext context, String homePage, String signInPage) {
-//   FirebaseAuth.instance.currentUser?.emailVerified == false
-//       ? customReplacementNavigate(context, signInPage)
-//       : customReplacementNavigate(context, homePage);
-// }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,21 +1,20 @@
 import 'package:ai_movie_app/app/my_app.dart';
 import 'package:ai_movie_app/core/services/service_locator.dart';
-// import 'package:ai_movie_app/core/utils/api_keys.dart';
+import 'package:ai_movie_app/core/utils/api_keys.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
-// import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  // Load environment variables
-  await dotenv.load(fileName: ".env");
+  await dotenv.load(fileName: "env/.env");
 
   //  Supabase Initialization
-  // await Supabase.initialize(
-  //   url: EnvConfig.supabaseUrl,
-  //   anonKey: EnvConfig.supabaseAnonKey,
-  // );
+  await Supabase.initialize(
+    url: EnvConfig.supabaseUrl,
+    anonKey: EnvConfig.supabaseAnonKey,
+  );
   await initSl();
   runApp(const SceneHub());
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -78,7 +78,7 @@ flutter:
   assets:
     - assets/images/
     - assets/icons/
-    - .env
+    - env/.env
   #   - images/a_dot_burr.jpeg
   #   - images/a_dot_ham.jpeg
 


### PR DESCRIPTION
• Implement SplashView with DecideStartDestinationUseCase for clean routing
• Set Splash as initial route and organize app navigation 
• Update Service Locator and App Router with splash dependencies 
• Integrate Supabase authentication and add .env configuration • Migrate navigation helpers to GoRouter
• Minor cleanup and project structure improvements